### PR TITLE
Sync with Asus-MSM8916 changes

### DIFF
--- a/light/android.hardware.light@2.0-service.asus_8953.rc
+++ b/light/android.hardware.light@2.0-service.asus_8953.rc
@@ -7,6 +7,7 @@ on init
     chmod 0664 /sys/class/leds/green/pwm_us
 
 service vendor.light-hal-2-0 /vendor/bin/hw/android.hardware.light@2.0-service.asus_8953
+    interface android.hardware.light@2.0::ILight default
     class hal
     user system
     group system


### PR DESCRIPTION
* Fixes light service not bound error in logs